### PR TITLE
Add build.rs to examples

### DIFF
--- a/examples/example1/Cargo.toml
+++ b/examples/example1/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
 name = "example"
 version = "0.1.0"
+build = "build.rs"
 
 [dependencies]
+
+[build-dependencies]
+rflex = { path = "../../" }

--- a/examples/example1/build.rs
+++ b/examples/example1/build.rs
@@ -4,5 +4,8 @@ use std::path::Path;
 fn main() {
     let path = Path::new("src").join("test.l");
     let path = path.to_str().unwrap().to_string();
-    rflex::process(path);
+    if let Err(e) = rflex::process(path) {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    }
 }

--- a/examples/example1/build.rs
+++ b/examples/example1/build.rs
@@ -1,0 +1,5 @@
+extern crate rflex;
+
+fn main() {
+    rflex::process("src/test.l".to_string());
+}

--- a/examples/example1/build.rs
+++ b/examples/example1/build.rs
@@ -1,5 +1,8 @@
 extern crate rflex;
+use std::path::Path;
 
 fn main() {
-    rflex::process("src/test.l".to_string());
+    let path = Path::new("src").join("test.l");
+    let path = path.to_str().unwrap().to_string();
+    rflex::process(path);
 }

--- a/examples/example2/Cargo.toml
+++ b/examples/example2/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
 name = "example"
 version = "0.1.0"
+build = "build.rs"
 
 [dependencies]
+
+[build-dependencies]
+rflex = { path = "../../" }

--- a/examples/example2/build.rs
+++ b/examples/example2/build.rs
@@ -4,5 +4,8 @@ use std::path::Path;
 fn main() {
     let path = Path::new("src").join("test.l");
     let path = path.to_str().unwrap().to_string();
-    rflex::process(path);
+    if let Err(e) = rflex::process(path) {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    }
 }

--- a/examples/example2/build.rs
+++ b/examples/example2/build.rs
@@ -1,0 +1,5 @@
+extern crate rflex;
+
+fn main() {
+    rflex::process("src/test.l".to_string());
+}

--- a/examples/example2/build.rs
+++ b/examples/example2/build.rs
@@ -1,5 +1,8 @@
 extern crate rflex;
+use std::path::Path;
 
 fn main() {
-    rflex::process("src/test.l".to_string());
+    let path = Path::new("src").join("test.l");
+    let path = path.to_str().unwrap().to_string();
+    rflex::process(path);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,33 @@
+mod scanner;
+mod nfa;
+mod dfa;
+mod codegen;
+mod charclasses;
+use crate::scanner::Scanner;
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+use std::path::Path;
+
+pub fn process(path: String) -> Result<(), std::io::Error> {
+    let f = File::open(path.clone())?;
+    let mut reader = BufReader::new(f);
+    let mut scanner = Scanner::new(&mut reader);
+    if let Err(_) = scanner.scan() {
+        std::process::exit(1);
+    }
+
+    scanner.build();
+
+    let path = Path::new(path.as_str());
+    let path = path.with_extension("rs");
+    let path_str = path.to_str();
+    if path_str.is_none() {
+        eprintln!("Cannot get path string for output");
+        std::process::exit(1);
+    }
+
+    let file = File::create(path_str.unwrap())?;
+    let mut writer = BufWriter::new(file);
+    scanner.generate(&mut writer)?;
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,47 +1,13 @@
-pub mod scanner;
-pub mod nfa;
-pub mod dfa;
-pub mod codegen;
-pub mod charclasses;
-use crate::scanner::Scanner;
-use std::fs::File;
-use std::io::{BufReader, BufWriter};
-use std::path::Path;
-
 fn help() {
     println!("usage:");
     println!("  rflex <target.l>");
-}
-
-fn process(path: String) -> Result<(), std::io::Error> {
-    let f = File::open(path.clone())?;
-    let mut reader = BufReader::new(f);
-    let mut scanner = Scanner::new(&mut reader);
-    if let Err(_) = scanner.scan() {
-        std::process::exit(1);
-    }
-
-    scanner.build();
-
-    let path = Path::new(path.as_str());
-    let path = path.with_extension("rs");
-    let path_str = path.to_str();
-    if path_str.is_none() {
-        eprintln!("Cannot get path string for output");
-        std::process::exit(1);
-    }
-
-    let file = File::create(path_str.unwrap())?;
-    let mut writer = BufWriter::new(file);
-    scanner.generate(&mut writer)?;
-    Ok(())
 }
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     match args.len() {
         2 => {
-            if let Err(e) = process(args[1].clone()) {
+            if let Err(e) = rflex::process(args[1].clone()) {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);
             }


### PR DESCRIPTION
This PR makes `process` function in main.rs move into lib.rs. Then we can call `process` from build.rs that means we don't have to call `rflex` in CLI for building package when we use build script.

I also added example of build script for examples.