### PR TITLE
Make DSL scanner enable to read multi-line action

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -21,12 +21,13 @@ Second one means the end of the rules.
 %class Lexer
 %result_type i32
 abc      println!("match abc rule"); return Ok(0i32);
-[a-z]+   println!("'{}'", self.yytext()); return Ok(10i32);
+[a-z]+   println!("'{}'", self.yytext());
+         return Ok(10i32); /* action can be defined in multiple lines that starts with white space */
 " "      /* Skip white space. This comment cannot be omitted. */
 %%
 ```
 
-The rule contains `pattern` and `action` in the **one** line.
+The rule contains `pattern` and `action` in the lines.
 `Pattern` is a regular-expression sequences.
 `Action` is a Rust code block to execute when the pattern accepted.
 In the above example, `abc` is pattern, `println!("match abc rule"); return Ok(0i32);` is action.

--- a/examples/example2/src/test.l
+++ b/examples/example2/src/test.l
@@ -4,13 +4,17 @@
 %class Lexer
 %result_type i32
 
-^abc             println!("'{}'", self.yytext()); return Ok(1i32);
-[a-z]+           println!("'{}'", self.yytext()); return Ok(10i32);
+^abc             println!("'{}'", self.yytext());
+                 return Ok(1i32);
+[a-z]+           println!("'{}'", self.yytext());
+                 return Ok(10i32);
 " "              println!("skip ws");
-\n               println!("skip nl"); self.yybegin(Lexer::HOGE);
+\n               println!("skip nl");
+                 self.yybegin(Lexer::HOGE);
 <HOGE>" "        println!("HOGE skip ws");
 <HOGE>\n         println!("HOGE skip nl");
-<HOGE>[a-z]+     println!("HOGE '{}'", self.yytext()); return Ok(100i32);
+<HOGE>[a-z]+     println!("HOGE '{}'", self.yytext());
+                 return Ok(100i32);
 <HOGE><<EOF>>    println!("HOGE-EOF");
 %%
 

--- a/examples/example2/src/test.rs
+++ b/examples/example2/src/test.rs
@@ -234,23 +234,29 @@ impl Lexer {
                     Lexer::ZZ_ACTION[zz_action as usize]
                 };
                 match action {
-                    1 => { println!("skip nl"); self.yybegin(Lexer::HOGE); }
+                    1 => { println!("skip nl");
+                 self.yybegin(Lexer::HOGE); }
                     10 => { /* nothing */ }
-                    2 => { println!("'{}'", self.yytext()); return Ok(10i32); }
+                    2 => { println!("'{}'", self.yytext());
+                 return Ok(10i32); }
                     11 => { /* nothing */ }
                     3 => { println!("skip ws"); }
                     12 => { /* nothing */ }
-                    4 => { println!("'{}'", self.yytext()); return Ok(10i32); }
+                    4 => { println!("'{}'", self.yytext());
+                 return Ok(10i32); }
                     13 => { /* nothing */ }
                     5 => { println!("HOGE skip nl"); }
                     14 => { /* nothing */ }
-                    6 => { println!("HOGE '{}'", self.yytext()); return Ok(100i32); }
+                    6 => { println!("HOGE '{}'", self.yytext());
+                 return Ok(100i32); }
                     15 => { /* nothing */ }
                     7 => { println!("HOGE skip ws"); }
                     16 => { /* nothing */ }
-                    8 => { println!("'{}'", self.yytext()); return Ok(10i32); }
+                    8 => { println!("'{}'", self.yytext());
+                 return Ok(10i32); }
                     17 => { /* nothing */ }
-                    9 => { println!("'{}'", self.yytext()); return Ok(1i32); }
+                    9 => { println!("'{}'", self.yytext());
+                 return Ok(1i32); }
                     18 => { /* nothing */ }
 
                     _ => {


### PR DESCRIPTION
This PR enables DSL(.l) scanner to read multi-line action (code block).