### PR TITLE
Provide explicit lifetime for transmute results

### DIFF
--- a/examples/example1/src/main.rs
+++ b/examples/example1/src/main.rs
@@ -1,8 +1,8 @@
 pub mod test;
 fn main() {
-    let s = "abc a A ABC abC_def".to_string();
+    let s = "abc a A ABC abC_def";
     //let s = "abc !".to_string();  // match unmatch
-    let mut lex = test::Lexer::new(s, test::SpaceCounter::new());
+    let mut lex = test::Lexer::new(&s, test::SpaceCounter::new());
     loop {
         let res = lex.yylex();
         println!("{:?}", res);

--- a/examples/example1/src/test.rs
+++ b/examples/example1/src/test.rs
@@ -24,11 +24,10 @@ pub enum Error {
     Unmatch,
 }
 
-pub struct Lexer {
-    input: String,
+pub struct Lexer<'a> {
     cmap: Vec<usize>,
-    start: std::str::Chars<'static>,
-    current: std::str::Chars<'static>,
+    start: std::str::Chars<'a>,
+    current: std::str::Chars<'a>,
     max_len: usize,
 
 
@@ -43,7 +42,7 @@ pub struct Lexer {
     space_counter: SpaceCounter,
 }
 
-impl Lexer {
+impl<'a> Lexer<'a> {
     pub const ZZ_ROW: [usize; 6] = [0, 7, 14, 21, 28, 14];
     pub const ZZ_TRANS: [i32; 35] = [-1, 1, 2, 2, 2, -1, 3, -1, 2, 4, 2, 2, 2, -1, -1, 2, 2, 2, 2, 2, -1, -1, -1, -1, -1, -1, -1, -1, -1, 2, 2, 5, 2, 2, -1];
     pub const ZZ_ATTR: [i32; 6] = [0, 1, 1, 9, 1, 1];
@@ -54,9 +53,9 @@ impl Lexer {
 
     pub const YYEOF: i32 = -1;
 
-    pub fn new(input: String, space_counter: SpaceCounter) -> Lexer {
+    pub fn new(input: &str, space_counter: SpaceCounter) -> Lexer<'a> {
         let max_len = input.chars().count();
-        let chars: std::str::Chars = unsafe { std::mem::transmute(input.chars()) };
+        let chars: std::str::Chars<'a> = unsafe { std::mem::transmute(input.chars()) };
         let mut cmap: Vec<usize> = Vec::with_capacity(0x110000);
         cmap.resize(0x110000, 0);
         cmap[32] = 6;
@@ -116,7 +115,6 @@ impl Lexer {
 
 
         Lexer {
-            input,
             cmap,
             start: chars.clone(),
             current: chars.clone(),

--- a/examples/example2/src/main.rs
+++ b/examples/example2/src/main.rs
@@ -1,8 +1,8 @@
 pub mod test;
 fn main() {
-    let s = "abc ab hoge fuga \nabc a a \nbcd \n abc abdef".to_string();
+    let s = "abc ab hoge fuga \nabc a a \nbcd \n abc abdef";
     //let s = "abc !".to_string();  // match unmatch
-    let mut lex = test::Lexer::new(s);
+    let mut lex = test::Lexer::new(&s);
     loop {
         let res = lex.yylex();
         println!("{:?}", res);

--- a/examples/example2/src/test.rs
+++ b/examples/example2/src/test.rs
@@ -7,11 +7,10 @@ pub enum Error {
     Unmatch,
 }
 
-pub struct Lexer {
-    input: String,
+pub struct Lexer<'a> {
     cmap: Vec<usize>,
-    start: std::str::Chars<'static>,
-    current: std::str::Chars<'static>,
+    start: std::str::Chars<'a>,
+    current: std::str::Chars<'a>,
     max_len: usize,
     previous: char,
 
@@ -25,7 +24,7 @@ pub struct Lexer {
 
 }
 
-impl Lexer {
+impl<'a> Lexer<'a> {
     pub const ZZ_ROW: [usize; 12] = [0, 7, 14, 21, 28, 21, 35, 21, 42, 21, 49, 28];
     pub const ZZ_TRANS: [i32; 56] = [-1, 3, 4, 4, 4, 4, 5, -1, 3, 6, 4, 4, 4, 5, -1, 7, 8, 8, 8, 8, 9, -1, -1, -1, -1, -1, -1, -1, -1, -1, 4, 4, 4, 4, -1, -1, -1, 4, 10, 4, 4, -1, -1, -1, 8, 8, 8, 8, -1, -1, -1, 4, 4, 11, 4, -1];
     pub const ZZ_ATTR: [i32; 12] = [0, 0, 0, 9, 1, 9, 1, 9, 1, 9, 1, 1];
@@ -37,9 +36,9 @@ impl Lexer {
 
     pub const YYEOF: i32 = -1;
 
-    pub fn new(input: String) -> Lexer {
+    pub fn new(input: &str) -> Lexer<'a> {
         let max_len = input.chars().count();
-        let chars: std::str::Chars = unsafe { std::mem::transmute(input.chars()) };
+        let chars: std::str::Chars<'a> = unsafe { std::mem::transmute(input.chars()) };
         let mut cmap: Vec<usize> = Vec::with_capacity(0x110000);
         cmap.resize(0x110000, 0);
         cmap[10] = 1;
@@ -79,7 +78,6 @@ impl Lexer {
 
 
         Lexer {
-            input,
             cmap,
             start: chars.clone(),
             current: chars.clone(),

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case)]
 
 use crate::scanner::Action;
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1196,11 +1196,10 @@ rankdir = LR
         EOF,
         Unmatch,
     }
-    struct Lexer {
-        input: String,
+    struct Lexer<'a> {
         cmap: Vec<usize>,
-        start: Chars<'static>,
-        current: Chars<'static>,
+        start: Chars<'a>,
+        current: Chars<'a>,
         max_len: usize,
 
         zz_state: usize,
@@ -1211,7 +1210,7 @@ rankdir = LR
         zz_at_eof: bool,
     }
 
-    impl Lexer {
+    impl<'a> Lexer<'a> {
         pub const ZZ_ROW: [usize; 8] = [0, 0, 7, 14, 21, 28, 35, 35];
         pub const ZZ_LEXSTATE: [i32; 2] = [0, 0];
         pub const ZZ_TRANS: [i32; 42] = [-1, 2, -1, -1, 3, -1, -1, -1, -1, 4, -1, -1, -1, -1, -1, -1, -1, -1, -1, 5, -1, -1, -1, -1, 6, -1, -1, -1, -1, -1, -1, -1, -1, -1, 7, -1, -1, -1, -1, -1, -1, -1];
@@ -1220,10 +1219,10 @@ rankdir = LR
         pub const YYINITIAL: usize = 0;
         pub const YYEOF: i32 = -1;
 
-        pub fn new(input: String) -> Lexer {
+        pub fn new(input: &str) -> Lexer<'a> {
             use std::mem;
             let max_len = input.chars().count();
-            let chars: Chars = unsafe { mem::transmute(input.chars()) };
+            let chars: Chars<'a> = unsafe { mem::transmute(input.chars()) };
             let mut cmap: Vec<usize> = Vec::with_capacity(0x110000);
             cmap.resize(0x110000, 0);
             // cmap - "abcdef"
@@ -1234,7 +1233,6 @@ rankdir = LR
             cmap[101] = 5;
             cmap[102] = 6;
             Lexer {
-                input,
                 cmap,
                 start: chars.clone(),
                 current: chars.clone(),


### PR DESCRIPTION
Prior to this change, the calls to std::mem::transmute produced an unbounded lifetime.

This change explicitly provides the lifetime parameter to the Chars reference.  In the case of a new lexer this lifetime is bound to the lexer itself.  Hence a lifetime parameter is also introduced, which in turn bound to the two chars iterators contained within it.

Also, the type of the input parameter to Lexer::new is changed from a String to a borrowed string slice (`&str`); this allows users to take advantage of Rust's deref coercion and is more idiomatic of Rust.

I assume that the call to the unsafe transmute is a work around the fact that the prior call to count consumes the string; or is there another reason?

Given that the documentation has this to say:

> `transmute` is *incredibly* unsafe. There are a vast number of ways to cause undefined behavior with this function. `transmute` should be the absolute last resort.

(Their emphasis) https://doc.rust-lang.org/std/mem/fn.transmute.html

Have you considered refactoring to avoid the call to transmute altogether?