### PR TITLE
Avoid calls to transmute

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -113,7 +113,7 @@ rflex has a `%field` directive to append any fields to lexer struct.
 That makes Lexer struct have `space_counter` field and generated impl is below:
 
 ```rust
-pub fn new(input: String, space_counter: SpaceCounter) -> Lexer { /* omission */ }
+pub fn new(input: &'a str, space_counter: SpaceCounter) -> Lexer<'a> { /* omission */ }
 pub fn get_space_counter(&mut self) -> &mut SpaceCounter { &mut self.space_counter } 
 
 ```

--- a/examples/example1/src/main.rs
+++ b/examples/example1/src/main.rs
@@ -1,8 +1,8 @@
 pub mod test;
 fn main() {
-    let s = "abc a A ABC abC_def".to_string();
+    let s = "abc a A ABC abC_def";
     //let s = "abc !".to_string();  // match unmatch
-    let mut lex = test::Lexer::new(s, test::SpaceCounter::new());
+    let mut lex = test::Lexer::new(&s, test::SpaceCounter::new());
     loop {
         let res = lex.yylex();
         println!("{:?}", res);

--- a/examples/example1/src/test.rs
+++ b/examples/example1/src/test.rs
@@ -24,11 +24,10 @@ pub enum Error {
     Unmatch,
 }
 
-pub struct Lexer {
-    input: String,
+pub struct Lexer<'a> {
     cmap: Vec<usize>,
-    start: std::str::Chars<'static>,
-    current: std::str::Chars<'static>,
+    start: std::str::Chars<'a>,
+    current: std::str::Chars<'a>,
     max_len: usize,
 
 
@@ -43,7 +42,7 @@ pub struct Lexer {
     space_counter: SpaceCounter,
 }
 
-impl Lexer {
+impl<'a> Lexer<'a> {
     pub const ZZ_ROW: [usize; 6] = [0, 7, 14, 21, 28, 14];
     pub const ZZ_TRANS: [i32; 35] = [-1, 1, 2, 2, 2, -1, 3, -1, 2, 4, 2, 2, 2, -1, -1, 2, 2, 2, 2, 2, -1, -1, -1, -1, -1, -1, -1, -1, -1, 2, 2, 5, 2, 2, -1];
     pub const ZZ_ATTR: [i32; 6] = [0, 1, 1, 9, 1, 1];
@@ -54,9 +53,9 @@ impl Lexer {
 
     pub const YYEOF: i32 = -1;
 
-    pub fn new(input: String, space_counter: SpaceCounter) -> Lexer {
-        let max_len = input.chars().count();
-        let chars: std::str::Chars = unsafe { std::mem::transmute(input.chars()) };
+    pub fn new(input: &'a str, space_counter: SpaceCounter) -> Lexer<'a> {
+        let max_len = input.chars().clone().count();
+        let chars = input.chars();
         let mut cmap: Vec<usize> = Vec::with_capacity(0x110000);
         cmap.resize(0x110000, 0);
         cmap[32] = 6;
@@ -116,7 +115,6 @@ impl Lexer {
 
 
         Lexer {
-            input,
             cmap,
             start: chars.clone(),
             current: chars.clone(),

--- a/examples/example2/src/main.rs
+++ b/examples/example2/src/main.rs
@@ -1,8 +1,8 @@
 pub mod test;
 fn main() {
-    let s = "abc ab hoge fuga \nabc a a \nbcd \n abc abdef".to_string();
+    let s = "abc ab hoge fuga \nabc a a \nbcd \n abc abdef";
     //let s = "abc !".to_string();  // match unmatch
-    let mut lex = test::Lexer::new(s);
+    let mut lex = test::Lexer::new(&s);
     loop {
         let res = lex.yylex();
         println!("{:?}", res);

--- a/examples/example2/src/test.rs
+++ b/examples/example2/src/test.rs
@@ -7,11 +7,10 @@ pub enum Error {
     Unmatch,
 }
 
-pub struct Lexer {
-    input: String,
+pub struct Lexer<'a> {
     cmap: Vec<usize>,
-    start: std::str::Chars<'static>,
-    current: std::str::Chars<'static>,
+    start: std::str::Chars<'a>,
+    current: std::str::Chars<'a>,
     max_len: usize,
     previous: char,
 
@@ -25,7 +24,7 @@ pub struct Lexer {
 
 }
 
-impl Lexer {
+impl<'a> Lexer<'a> {
     pub const ZZ_ROW: [usize; 12] = [0, 7, 14, 21, 28, 21, 35, 21, 42, 21, 49, 28];
     pub const ZZ_TRANS: [i32; 56] = [-1, 3, 4, 4, 4, 4, 5, -1, 3, 6, 4, 4, 4, 5, -1, 7, 8, 8, 8, 8, 9, -1, -1, -1, -1, -1, -1, -1, -1, -1, 4, 4, 4, 4, -1, -1, -1, 4, 10, 4, 4, -1, -1, -1, 8, 8, 8, 8, -1, -1, -1, 4, 4, 11, 4, -1];
     pub const ZZ_ATTR: [i32; 12] = [0, 0, 0, 9, 1, 9, 1, 9, 1, 9, 1, 1];
@@ -37,9 +36,9 @@ impl Lexer {
 
     pub const YYEOF: i32 = -1;
 
-    pub fn new(input: String) -> Lexer {
-        let max_len = input.chars().count();
-        let chars: std::str::Chars = unsafe { std::mem::transmute(input.chars()) };
+    pub fn new(input: &'a str) -> Lexer<'a> {
+        let max_len = input.chars().clone().count();
+        let chars = input.chars();
         let mut cmap: Vec<usize> = Vec::with_capacity(0x110000);
         cmap.resize(0x110000, 0);
         cmap[10] = 1;
@@ -79,7 +78,6 @@ impl Lexer {
 
 
         Lexer {
-            input,
             cmap,
             start: chars.clone(),
             current: chars.clone(),

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -279,11 +279,10 @@ pub enum Error {
     Unmatch,
 }
 
-pub struct {{lexer_name}} {
-    input: String,
+pub struct {{lexer_name}}<'a> {
     cmap: Vec<usize>,
-    start: std::str::Chars<'static>,
-    current: std::str::Chars<'static>,
+    start: std::str::Chars<'a>,
+    current: std::str::Chars<'a>,
     max_len: usize,
 {{ previous_def }}
 
@@ -297,7 +296,7 @@ pub struct {{lexer_name}} {
 {{ fields_def }}
 }
 
-impl {{lexer_name}} {
+impl<'a> {{lexer_name}}<'a> {
     pub const ZZ_ROW: [usize; {{row_num}}] = {{row_value}};
     pub const ZZ_TRANS: [i32; {{trans_num}}] = {{trans_value}};
     pub const ZZ_ATTR: [i32; {{attr_num}}] = {{attr_value}};
@@ -307,15 +306,14 @@ impl {{lexer_name}} {
 
     pub const YYEOF: i32 = -1;
 
-    pub fn new(input: String{{ fields_args }}) -> {{lexer_name}} {
-        let max_len = input.chars().count();
-        let chars: std::str::Chars = unsafe { std::mem::transmute(input.chars()) };
+    pub fn new(input: &'a str{{ fields_args }}) -> {{lexer_name}}<'a> {
+        let max_len = input.chars().clone().count();
+        let chars = input.chars();
         let mut cmap: Vec<usize> = Vec::with_capacity(0x110000);
         cmap.resize(0x110000, 0);
 {{cmap_values}}
 
         {{lexer_name}} {
-            input,
             cmap,
             start: chars.clone(),
             current: chars.clone(),

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case)]
 
 use crate::scanner::Action;
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1173,8 +1173,8 @@ rankdir = LR
 
     #[test]
     fn lexer_1() {
-        let s = "abcdef".to_string();
-        let mut l = Lexer::new(s);
+        let s = "abcdef";
+        let mut l = Lexer::new(&s);
 
         assert_eq!(Ok(1i32), l.next_token());
         assert_eq!(Ok(2i32), l.next_token());
@@ -1184,8 +1184,8 @@ rankdir = LR
 
     #[test]
     fn lexer_2() {
-        let s = "abcUNMATCH".to_string();
-        let mut l = Lexer::new(s);
+        let s = "abcUNMATCH";
+        let mut l = Lexer::new(&s);
 
         assert_eq!(Ok(1i32), l.next_token());
         assert_eq!(Err(LexerError::Unmatch), l.next_token());
@@ -1196,11 +1196,10 @@ rankdir = LR
         EOF,
         Unmatch,
     }
-    struct Lexer {
-        input: String,
+    struct Lexer<'a> {
         cmap: Vec<usize>,
-        start: Chars<'static>,
-        current: Chars<'static>,
+        start: Chars<'a>,
+        current: Chars<'a>,
         max_len: usize,
 
         zz_state: usize,
@@ -1211,7 +1210,7 @@ rankdir = LR
         zz_at_eof: bool,
     }
 
-    impl Lexer {
+    impl<'a> Lexer<'a> {
         pub const ZZ_ROW: [usize; 8] = [0, 0, 7, 14, 21, 28, 35, 35];
         pub const ZZ_LEXSTATE: [i32; 2] = [0, 0];
         pub const ZZ_TRANS: [i32; 42] = [-1, 2, -1, -1, 3, -1, -1, -1, -1, 4, -1, -1, -1, -1, -1, -1, -1, -1, -1, 5, -1, -1, -1, -1, 6, -1, -1, -1, -1, -1, -1, -1, -1, -1, 7, -1, -1, -1, -1, -1, -1, -1];
@@ -1220,10 +1219,10 @@ rankdir = LR
         pub const YYINITIAL: usize = 0;
         pub const YYEOF: i32 = -1;
 
-        pub fn new(input: String) -> Lexer {
+        pub fn new(input: &'a str) -> Lexer<'a> {
             use std::mem;
-            let max_len = input.chars().count();
-            let chars: Chars = unsafe { mem::transmute(input.chars()) };
+            let max_len = input.chars().clone().count();
+            let chars = input.chars();
             let mut cmap: Vec<usize> = Vec::with_capacity(0x110000);
             cmap.resize(0x110000, 0);
             // cmap - "abcdef"
@@ -1234,7 +1233,6 @@ rankdir = LR
             cmap[101] = 5;
             cmap[102] = 6;
             Lexer {
-                input,
                 cmap,
                 start: chars.clone(),
                 current: chars.clone(),


### PR DESCRIPTION
Prior to this change, std::mem::transmute was used to circumvent Rust's
borrow-checker.  This function is *incredibly* unsafe... best to avoid
it.  The call was doing two things: (1) it allowed the input string to
be borrowed after being consumed by the call to count; and (2) created a
new unbounded lifetime for the returned char iterator.

This change introduces a lifetime parameter to the lexer struct which
can then be bound to the lifetime of the char iterator.  Also, we clone
the iterator before calling count.  These measures overcome the two
problems above.

https://doc.rust-lang.org/std/mem/fn.transmute.html
https://doc.rust-lang.org/nomicon/unbounded-lifetimes.html

This PR replaces the need for #4.